### PR TITLE
docs: add example inspecting a Python MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,20 @@ Grizzly packages a bunch of additional features :
 
 ### From an MCP server repository
 
-To inspect an MCP server implementation, there's no need to clone this repo. Instead, use `npx`. For example, if your server is built at `build/index.js`:
+To inspect an MCP server implementation, there's no need to clone this repo. Instead, use `npx`. 
+
+#### Example 1 - MCP server built with JavaScript/TypeScript/Node.js
+If your server is built at `build/index.js`:
 
 ```bash
 npx @alpic-ai/grizzly node build/index.js
+```
+
+#### Example 2 - MCP server built with Python
+If your server is built at `./main.py`:
+
+```bash
+npx @alpic-ai/grizzly uv run main.py
 ```
 
 You can pass both arguments and environment variables to your MCP server. Arguments are passed directly to your server, while environment variables can be set using the `-e` flag:


### PR DESCRIPTION
Update README with examples of MCP servers built in different languages:

- [x] Add example inspecting a Python MCP server
- [x] Organize examples per programming language used to build the MCP server
- [x] Tested with [Devopness MCP server](https://github.com/devopness/devopness)